### PR TITLE
feat: Configure timestamp and schedule generation for SessionSeries feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # lorem-fitsum
+
 Random activity generator
+
+Env vars:
+
+- `FEED_SESSIONSERIES_PAGE_SIZE` (OPTIONAL)
+  Number of items in each page for the SessionSeries feed
+  Defaults to `60`
+- `FEED_SESSIONSERIES_TIMESTAMP_INVERVAL_MINUTES` (OPTIONAL)
+  Number of minutes in between each generated item within a page for the SessionSeries feed. Must be a factor of 60
+  e.g.
+  - `10`: The 2nd item in each feed will start 10 minutes after the 1st. The 3rd will start 10 minutes after the 2nd. etc.
+  Defaults to `5`
+- `SCHEDULE_MAX_END_DAY_OFFSET` (OPTIONAL)
+  Maximum number of days offset between an item's timestamp and the endDate of its schedule. The endDate will be random, but its maximum possible value will use this offset.
+  Defaults to `28`
+- `SCHEDULE_MIN_END_DAY_OFFSET` (OPTIONAL)
+  Minimum number of days offset between an item's timestamp and the endDate of its schedule. The endDate will be random, but its minimum possible value will use this offset.
+  Defaults to `14`
+- `SCHEDULE_START_DAY_OFFSET` (OPTIONAL)
+  Number of days offset between an item's timestamp and the startDate of its schedule. Should be negative!
+  Defaults to `-7`
+- `TIMESTAMP_START_DAY_OFFSET` (OPTIONAL)
+  Number of days offset between now and the first `modified` timestamp in the feed. Should be negative (as `modified` timestamps must be in the past) e.g.
+  - `-14`: The first item in each feed will start 14 days ago
+  - `-7`: The first item in each feed will start 7 days ago
+  Defaults to `-14`

--- a/bin/www
+++ b/bin/www
@@ -3,7 +3,7 @@
 /**
  * Module dependencies.
  */
-
+require('dotenv').config();
 var app = require('../app');
 var debug = require('debug')('lorem-fitsum:server');
 var http = require('http');

--- a/env.js
+++ b/env.js
@@ -1,0 +1,32 @@
+/**
+ * @param {string} envVarName
+ * @param {number} defaultValue
+ * @returns {number}
+ */
+function parseNumberFromOptionalEnvVar(envVarName, defaultValue) {
+  const envVarValue = process.env[envVarName];
+  if (envVarValue == null || envVarValue === '') {
+    return defaultValue;
+  }
+  const asNumber = Number(envVarValue);
+  if (Number.isNaN(asNumber)) {
+    throw new Error(`Env var "${envVarName}" should be a number or blank. It is not. Value: "${envVarValue}"`);
+  }
+  return asNumber;
+}
+
+const FEED_SESSIONSERIES_PAGE_SIZE = parseNumberFromOptionalEnvVar('FEED_SESSIONSERIES_PAGE_SIZE', 60);
+const FEED_SESSIONSERIES_TIMESTAMP_INVERVAL_MINUTES = parseNumberFromOptionalEnvVar('FEED_SESSIONSERIES_TIMESTAMP_INVERVAL_MINUTES', 5);
+const SCHEDULE_MAX_END_DAY_OFFSET = parseNumberFromOptionalEnvVar('SCHEDULE_MAX_END_DAY_OFFSET', 28);
+const SCHEDULE_MIN_END_DAY_OFFSET = parseNumberFromOptionalEnvVar('SCHEDULE_MIN_END_DAY_OFFSET', 14);
+const SCHEDULE_START_DAY_OFFSET = parseNumberFromOptionalEnvVar('SCHEDULE_START_DAY_OFFSET', -7);
+const TIMESTAMP_START_DAY_OFFSET = parseNumberFromOptionalEnvVar('TIMESTAMP_START_DAY_OFFSET', -14);
+
+module.exports = {
+  FEED_SESSIONSERIES_PAGE_SIZE,
+  FEED_SESSIONSERIES_TIMESTAMP_INVERVAL_MINUTES,
+  SCHEDULE_MAX_END_DAY_OFFSET,
+  SCHEDULE_MIN_END_DAY_OFFSET,
+  SCHEDULE_START_DAY_OFFSET,
+  TIMESTAMP_START_DAY_OFFSET,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -175,6 +175,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@openactive/skos": "^1.0.16",
     "cookie-parser": "~1.4.3",
     "debug": "~2.6.9",
+    "dotenv": "^8.2.0",
     "ejs": "~2.5.7",
     "express": "~4.16.0",
     "faker": "^4.1.0",
@@ -20,6 +21,10 @@
     "morgan": "~1.9.0",
     "rrule": "^2.5.6",
     "sync-request": "^6.0.0"
+  },
+  "engines": {
+    "node": "12.16.1",
+    "npm": "6.13.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## QA

Env vars I had set in a local `.env` file:

![Screenshot 2020-03-27 at 20 01 20](https://user-images.githubusercontent.com/2067438/77799343-80542b00-706c-11ea-9de8-c11769cf93be.png)

Example of page size being used:

![Screenshot 2020-03-27 at 20 45 15](https://user-images.githubusercontent.com/2067438/77799356-8518df00-706c-11ea-9f06-7c15d3546bf5.png)

First modified timestamp:

![Screenshot 2020-03-27 at 20 45 42](https://user-images.githubusercontent.com/2067438/77799368-8cd88380-706c-11ea-8a13-3e6563572f1b.png)

An event schedule:

![Screenshot 2020-03-27 at 20 48 28](https://user-images.githubusercontent.com/2067438/77799415-a8dc2500-706c-11ea-928c-5de24b5eb469.png)

